### PR TITLE
Removed bevy_egui from reserved crates

### DIFF
--- a/reserved_crates
+++ b/reserved_crates
@@ -14,7 +14,6 @@ bevy_csharp
 bevy_curve
 bevy_demo
 bevy_editor
-bevy_egui
 bevy_event
 bevy_executor
 bevy_extra


### PR DESCRIPTION
As discussed here https://github.com/bevyengine/bevy/pull/2766#discussion_r705668476, `bevy_egui` is already a [third party crate](https://github.com/mvlabat/bevy_egui)