### PR TITLE
Add bevy_a11y and bevy_i18n

### DIFF
--- a/reserved_crates
+++ b/reserved_crates
@@ -1,3 +1,4 @@
+bevy_a11y
 bevy_ai
 bevy_android
 bevy_animation
@@ -27,6 +28,7 @@ bevy_gpu
 bevy_graph
 bevy_hierarchy
 bevy_ik
+bevy_i18n
 bevy_imgui
 bevy_ios
 bevy_jobs


### PR DESCRIPTION
With bevyengine/bevy#6874 looking to be mergable soon, we should probably reserve bevy_a11y before someone squats it.

Following this trend, I also added `bevy_i18n` for the corresponding internationalization parallel to a11y.